### PR TITLE
Fix slight visual offset on Safari mobile

### DIFF
--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -14,7 +14,7 @@ const CanvasWrapper: FC<Props> = ({ children, canvasProps = {} }) => {
     const observer = new ResizeObserver(([entry]) => {
       const { width, height } = entry.contentRect
       setSize({
-        width: Math.round(width % 2 === 0 ? width + 1 : width),
+        width: Math.round(width % 2 !== 0 ? width + 1 : width),
         height: Math.round(height % 2 !== 0 ? height + 1 : height),
       })
     })


### PR DESCRIPTION
Having an odd-numbered width still results in an offset, albeit not as significant as when the height is odd. Tested on iPhone and Mac, used in production at lovedove.co